### PR TITLE
Modified config.h and info.json to successfully compile with QMK v1.1…

### DIFF
--- a/QMK firmware/mousejiggler/config.h
+++ b/QMK firmware/mousejiggler/config.h
@@ -1,38 +1,38 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include "config_common.h"
+// #include "config_common.h"
 
 /* USB Device descriptor parameter */
-#define VENDOR_ID       0x0001
-#define PRODUCT_ID      0x0001
-#define DEVICE_VER      0x0001
-#define MANUFACTURER    Microsoft Wired Keyboard
-#define PRODUCT         Microsoft Wired Keyboard
-#define DESCRIPTION     Microsoft Wired Keyboard
+//#define VENDOR_ID       0x0001
+//#define PRODUCT_ID      0x0001
+//#define DEVICE_VER      0x0001
+//#define MANUFACTURER    Microsoft Wired Keyboard
+//#define PRODUCT         Microsoft Wired Keyboard
+//#define DESCRIPTION     Microsoft Wired Keyboard
 
 /* key matrix size */
-#define MATRIX_ROWS 1
-#define MATRIX_COLS 1
+// #define MATRIX_ROWS 1
+// #define MATRIX_COLS 1
 
 /* key matrix pins */
-#define MATRIX_ROW_PINS { B5 }
-#define MATRIX_COL_PINS { D7 }
-#define UNUSED_PINS
+// #define MATRIX_ROW_PINS { B5 }
+// #define MATRIX_COL_PINS { D7 }
+//#define UNUSED_PINS
 
 
 
 /* COL2ROW or ROW2COL */
-#define DIODE_DIRECTION COL2ROW
+// #define DIODE_DIRECTION COL2ROW
 
 /* number of backlight levels */
 
 #ifdef BACKLIGHT_PIN
-#define BACKLIGHT_LEVELS 0
+#define BACKLIGHT_LEVELS 1
 #endif
 
 /* Set 0 if debouncing isn't needed */
-#define DEBOUNCING_DELAY 0
+#define DEBOUNCE 20
 
 
 

--- a/QMK firmware/mousejiggler/info.json
+++ b/QMK firmware/mousejiggler/info.json
@@ -1,12 +1,23 @@
 {
   "keyboard_name": "mousejiggler",
+  "manufacturer": "skullydazed",
   "url": "",
   "maintainer": "skullydazed",
-  "width": 2,
-  "height": 2,
+  "usb": {
+    "vid": "0x0001",
+    "pid": "0x0001",
+    "device_version": "1.1.0"
+  },
+  "matrix_pins": {
+    "cols": ["B5"],
+    "rows": ["D7"]
+  },
+  "diode_direction": "COL2ROW",
+  "processor": "atmega32u4",
+  "bootloader": "caterina",
   "layouts": {
-      "LAYOUT_ortho_2x2": {
-          "layout": [{"x":0, "y":0}, {"x":1, "y":0}, {"x":0, "y":1}, {"x":1, "y":1}]
-      }
-  }
+    "LAYOUT": {
+        "layout": [{"matrix": [0, 0], "x": 0, "y": 0}]
+    }
+}
 }

--- a/QMK firmware/mousejiggler/keymaps/default/keymap.c
+++ b/QMK firmware/mousejiggler/keymaps/default/keymap.c
@@ -32,22 +32,22 @@ void matrix_scan_user(void) {
 }
 
 
-bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  switch (keycode) {
-    case MOUSEJIGGLERMACRO:
-      if (record->event.pressed) {
-        mouse_jiggle_mode = true;
-      } else {
-        mouse_jiggle_mode = false;
-      }
-      break;
-  }
-  return true;
-}
+// bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+//   switch (keycode) {
+//     case MOUSEJIGGLERMACRO:
+//       if (record->event.pressed) {
+//         mouse_jiggle_mode = true;
+//       } else {
+//         mouse_jiggle_mode = false;
+//       }
+//       break;
+//   }
+//   return true;
+// }
 
 
 //if you want it to be a toggle switch with a key instead of a hold down function use this instead
-/*
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case MOUSEJIGGLERMACRO:


### PR DESCRIPTION
The repository would not compile with QMK v1.1.1 due to some deprecated parameters used in `config.h` and `info.json`, causing build errors. I have made changes in these two files and successfully built and ran the mousejiggler on an Arduino pro micro. Note that I have also edited `keymap.c` for my key to be "tap to toggle" as per your instructions. Users might want to revert that change if desired so.